### PR TITLE
Fix CA1822: Method may be declared static

### DIFF
--- a/src/ListBlockRenderer.cs
+++ b/src/ListBlockRenderer.cs
@@ -38,7 +38,7 @@ namespace Microsoft.PowerShell.MarkdownRender
             renderer.WriteLine();
         }
 
-        private void RenderNumberedList(VT100Renderer renderer, ListItemBlock block, int index)
+        private static void RenderNumberedList(VT100Renderer renderer, ListItemBlock block, int index)
         {
             // For a numbered list, we need to make sure the index is incremented.
             foreach (var line in block)

--- a/src/ListItemBlockRenderer.cs
+++ b/src/ListItemBlockRenderer.cs
@@ -30,7 +30,7 @@ namespace Microsoft.PowerShell.MarkdownRender
             }
         }
 
-        private void RenderWithIndent(VT100Renderer renderer, MarkdownObject block, char listBullet, int indentLevel)
+        private static void RenderWithIndent(VT100Renderer renderer, MarkdownObject block, char listBullet, int indentLevel)
         {
             // Indent left by 2 for each level on list.
             string indent = Padding(indentLevel * 2);


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1822