### PR TITLE
Fix the indentation of conditional for Nuget task

### DIFF
--- a/yaml/template/publish.yml
+++ b/yaml/template/publish.yml
@@ -50,4 +50,4 @@ stages:
               packagesToPush: '$(NugetPkgPath)'
               nuGetFeedType: external
               publishFeedCredentials: ${{ parameters.feedCredential }}
-              condition: eq('${{ parameters.feedUrl }}', '')
+            condition: eq('${{ parameters.feedUrl }}', '')


### PR DESCRIPTION
Fix yaml indentation which cause the condition to not work.