### PR TITLE
fix: MarkdownInfo.ToString() should be HTML ( Fixes #28 )

### DIFF
--- a/src/MarkdownConverter.cs
+++ b/src/MarkdownConverter.cs
@@ -44,6 +44,14 @@ namespace Microsoft.PowerShell.MarkdownRender
         /// Gets the AST of the Markdown string.
         /// </summary>
         public Markdig.Syntax.MarkdownDocument Tokens { get; internal set; }
+
+
+        /// <summary>
+        /// Gets the converted markdown as a string.
+        /// </summary>
+        public string ToString() {
+            return this.Html;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

Adding a `ToString()` to `[MarkdownInfo]` that will output the `.HTML`
<!-- Summarize your PR between here and the checklist. -->

This will make converted markdown easier to embed in HTML, match, join (and all other string operations)

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

This seems like a very sensible default, and it will make pages built out of multiple markdowns significantly easier to construct.